### PR TITLE
Gitlab連携時、HTMLのコメントを無視するように

### DIFF
--- a/resolvers/gitlab.py
+++ b/resolvers/gitlab.py
@@ -7,10 +7,14 @@ import requests
 from . import skip_bot_message
 
 
+GITLAB_DOMAIN = os.environ['GITLAB_DOMAIN']
+GITLAB_ID_PATTERN = re.compile(f'{GITLAB_DOMAIN}/(.+)/(issues|merge_requests)/(\d+)')
+COMMENT_PATTERN = re.compile(r'''<!--.*?-->''', re.MULTILINE | re.DOTALL)
+
+
 @skip_bot_message
 def resolve(post_message, event):
-    GITLAB_DOMAIN = os.environ['GITLAB_DOMAIN']
-    ids = re.findall(f'{GITLAB_DOMAIN}/(.+)/(issues|merge_requests)/(\d+)', event['text'])
+    ids = GITLAB_ID_PATTERN.findall(event['text'])
     for project, issue_type, issue_id in ids:
         project_id = urllib.parse.quote_plus(project)
         issue = requests.get(
@@ -30,6 +34,5 @@ def resolve(post_message, event):
         )
 
 def trim_html_comment(html):
-    COMMENT_PATTERN = re.compile(r'''<!--.*?-->''')
     return COMMENT_PATTERN.sub('', html)
     

--- a/resolvers/gitlab.py
+++ b/resolvers/gitlab.py
@@ -22,9 +22,14 @@ def resolve(post_message, event):
                 'color': '#eb763d',
                 'title': f"[{project}]{issue['title']}",
                 'title_link': issue['web_url'],
-                'text': issue['description'],
+                'text': trim_html_comment(issue['description']),
                 'author_name': issue['author']['name'],
                 'author_icon': issue['author'].get('avatar_url'),
                 'author_link': issue['author']['web_url'],
             }]
         )
+
+def trim_html_comment(html):
+    COMMENT_PATTERN = re.compile(r'''<!--.*?-->''')
+    return COMMENT_PATTERN.sub('', html)
+    

--- a/resolvers/gitlab.py
+++ b/resolvers/gitlab.py
@@ -7,7 +7,7 @@ import requests
 from . import skip_bot_message
 
 
-GITLAB_DOMAIN = os.environ['GITLAB_DOMAIN']
+GITLAB_DOMAIN = os.environ.get('GITLAB_DOMAIN', '')
 GITLAB_ID_PATTERN = re.compile(f'{GITLAB_DOMAIN}/(.+)/(issues|merge_requests)/(\d+)')
 COMMENT_PATTERN = re.compile(r'''<!--.*?-->''', re.MULTILINE | re.DOTALL)
 

--- a/tests/resolvers/test_gitlab.py
+++ b/tests/resolvers/test_gitlab.py
@@ -3,10 +3,26 @@
 from resolvers.gitlab import trim_html_comment
 
 
-sample_message = """# Hello World.
-<!-- Test Comment -->
-This is test message.
-<!---->"""
+SAMPLE_HTML = '''# The Zen of Python
+Beautiful is better than ugly.
+<!-- comment --><!-- comment -->
+Explicit is better than implicit.
+<!--
+  Multi line comment
+-->
+Simple is better than complex.
+<!---->
+...'''
+
+EXPECTED_HTML = '''# The Zen of Python
+Beautiful is better than ugly.
+
+Explicit is better than implicit.
+
+Simple is better than complex.
+
+...'''
+
 
 def test_trim_html_comment():
-    assert trim_html_comment(sample_message) ==  '# Hello World.\n\nThis is test message.\n'
+    assert trim_html_comment(SAMPLE_HTML) ==  EXPECTED_HTML

--- a/tests/resolvers/test_gitlab.py
+++ b/tests/resolvers/test_gitlab.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+from resolvers.gitlab import trim_html_comment
+
+
+sample_message = """# Hello World.
+<!-- Test Comment -->
+This is test message.
+<!---->"""
+
+def test_trim_html_comment():
+    assert trim_html_comment(sample_message) ==  '# Hello World.\n\nThis is test message.\n'


### PR DESCRIPTION
gitlabのissueテンプレートにHTMLのコメントが含まれていると見づらかったので、HTMLのコメント部分を無視してSlackに投げるようにしてみました。:bow: